### PR TITLE
fix: add $ helper and move extends to .extends(..) for proper inheritance

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+pnpm-lock.yaml
+node_modules
+lib
+*.md

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/jest": "^29.5.4",
     "@types/node": "^16",
     "jest": "^29.7.0",
-    "prettier": "^3.0.3",
+    "prettier": "^2",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zod-class",
   "description": "Create classes from Zod Object schemas all in one line",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ devDependencies:
     specifier: ^29.7.0
     version: 29.7.0(@types/node@16.18.11)(ts-node@10.9.1)
   prettier:
-    specifier: ^3.0.3
-    version: 3.0.3
+    specifier: ^2
+    version: 2.0.0
   ts-jest:
     specifier: ^29.1.1
     version: 29.1.1(@babel/core@7.22.17)(jest@29.7.0)(typescript@5.2.2)
@@ -2032,9 +2032,9 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /prettier@3.0.3:
-    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
-    engines: {node: '>=14'}
+  /prettier@2.0.0:
+    resolution: {integrity: sha512-vI55PC+GFLOVtpwr2di1mYhJF36v+kztJov8sx3AmqbfdA+2Dhozxb+3e1hTgoV9lyhnVJFF3Z8GCVeMBOS1bA==}
+    engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
 

--- a/test/zod-class.test.ts
+++ b/test/zod-class.test.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ZodClass } from "../src/index.js";
+import { ZodClass, $ } from "../src/index.js";
 
 test("support extending classes", () => {
   class Foo extends ZodClass({
@@ -21,7 +21,7 @@ test("support extending classes", () => {
   expect(parsedFoo instanceof Foo).toBe(true);
   expect(foo).toMatchObject(parsedFoo);
 
-  class Bar extends Foo.extend({
+  class Bar extends $(Foo).extend({
     baz: z.literal("Forty"),
   }) {
     getFoo() {
@@ -48,6 +48,7 @@ test("support extending classes", () => {
     const two: "Two" = bar.getBaz();
   }).toThrow();
 
+
   const bar = new Bar({
     foo: "foo",
     bar: 1,
@@ -68,3 +69,53 @@ test("support extending classes", () => {
   expect(bar.getBaz()).toEqual("Forty");
   expect(bar.getBaz()).toEqual(parsedBar.getBaz());
 });
+
+
+test("should inherit class methods", () => {
+  class Foo extends ZodClass({
+    foo: z.string()
+  }) {
+    getFoo() {
+      return this.foo;
+    }
+  }
+  
+  class Bar extends $(Foo).extend({
+    foo: z.literal('forty-two'),
+    bar: z.number()
+  }) {
+    getBar() {
+      return this.bar;
+    }
+  }
+  
+  const barSchema = {
+    foo: 'forty-two',
+    bar: 42,
+  }
+  
+  const bar = Bar.parse<Bar>(barSchema);
+
+  expect(bar.getFoo()).toEqual("forty-two")
+  expect(bar.getBar()).toEqual(42)
+
+  class Baz extends $(Bar).extend({
+    baz: z.string()
+  }) {
+    getFoo() {
+      return `foo: ${super.getFoo()}`;
+    }
+    getBaz() {
+      return this.baz;
+    }
+  }
+
+  const baz = new Baz({
+    bar: 42,
+    foo: 'forty-two',
+    baz: 'baz'
+  })
+
+  expect(baz.getFoo()).toEqual("foo: forty-two")
+  expect(baz.getBaz()).toEqual("baz")
+})

--- a/test/zod-class.test.ts
+++ b/test/zod-class.test.ts
@@ -48,7 +48,6 @@ test("support extending classes", () => {
     const two: "Two" = bar.getBaz();
   }).toThrow();
 
-
   const bar = new Bar({
     foo: "foo",
     bar: 1,
@@ -70,37 +69,36 @@ test("support extending classes", () => {
   expect(bar.getBaz()).toEqual(parsedBar.getBaz());
 });
 
-
 test("should inherit class methods", () => {
   class Foo extends ZodClass({
-    foo: z.string()
+    foo: z.string(),
   }) {
     getFoo() {
       return this.foo;
     }
   }
-  
+
   class Bar extends $(Foo).extend({
-    foo: z.literal('forty-two'),
-    bar: z.number()
+    foo: z.literal("forty-two"),
+    bar: z.number(),
   }) {
     getBar() {
       return this.bar;
     }
   }
-  
+
   const barSchema = {
-    foo: 'forty-two',
+    foo: "forty-two",
     bar: 42,
-  }
-  
+  };
+
   const bar = Bar.parse<Bar>(barSchema);
 
-  expect(bar.getFoo()).toEqual("forty-two")
-  expect(bar.getBar()).toEqual(42)
+  expect(bar.getFoo()).toEqual("forty-two");
+  expect(bar.getBar()).toEqual(42);
 
   class Baz extends $(Bar).extend({
-    baz: z.string()
+    baz: z.string(),
   }) {
     getFoo() {
       return `foo: ${super.getFoo()}`;
@@ -112,10 +110,10 @@ test("should inherit class methods", () => {
 
   const baz = new Baz({
     bar: 42,
-    foo: 'forty-two',
-    baz: 'baz'
-  })
+    foo: "forty-two",
+    baz: "baz",
+  });
 
-  expect(baz.getFoo()).toEqual("foo: forty-two")
-  expect(baz.getBaz()).toEqual("baz")
-})
+  expect(baz.getFoo()).toEqual("foo: forty-two");
+  expect(baz.getBaz()).toEqual("baz");
+});


### PR DESCRIPTION
Closes #2 

I moved `extends` off of the class and onto a helper, `$`, so that we can capture the actual class instance type when extending a class.

See #2 for the discussion on why this needed to happen. In short, the previous version was trying to define all the types on the generated class, but this all happens prior to the `Foo` (base) type is declared and `this` type doesn't work properly in a static context, so it can't be used to get a reference to the `Foo` type within the mix-in. To workaround this, `$(Foo)` captures the concrete `Foo` type, including any methods it extends, allowing the class's full definition to be extended.

This is a similar problem to `Foo.parse<Foo>()` which could be replaced with `$(Foo).parse(..)` to avoid the redundant `parse<Foo>`.

The following test cases works:
```ts
class Foo extends ZodClass({
  foo: z.string()
}) {
  getFoo() {
    return this.foo;
  }
}

class Bar extends $(Foo).extend({
  foo: z.literal('forty-two'),
  bar: z.number()
}) {
  getBar() {
    return this.bar;
  }
}

const barSchema = {
  foo: 'forty-two',
  bar: 42,
}

const bar = Bar.parse<Bar>(barSchema);

expect(bar.getFoo()).toEqual("forty-two")
expect(bar.getBar()).toEqual(42)

class Baz extends $(Bar).extend({
  baz: z.string()
}) {
  getFoo() {
    return `foo: ${super.getFoo()}`;
  }
  getBaz() {
    return this.baz;
  }
}

const baz = new Baz({
  bar: 42,
  foo: 'forty-two',
  baz: 'baz'
})

expect(baz.getFoo()).toEqual("foo: forty-two")
expect(baz.getBaz()).toEqual("baz")
```