### PR TITLE
feat: overload Z so there's one utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,41 @@ npm install zod-class
 
 ## Usage
 
+The `$` utility function is the swiss army knife in `zod-class` - you use it for everything.
+
+1. Define a new class
 
 ```ts
 import z from "zod";
-import { ZodClass } from "zod-class";
+import { $ } from "zod-class";
 
 // define a class using a zod schema
-export class Hello extends ZodClass({
-  hello: z.string(),
-}) {}
+export class Hello extends $({
+  name: z.string(),
+}) {
+  get message() {
+    return `hello ${name}`
+  }
+}
 
 const hello = new Hello({
   hello: "sam",
 });
+```
 
-// extend a class
-export class World extends Hello.extend({
+2. Parse a value to an instance of a ZodClass
+```ts
+const hello = $(Hello).parse(someVal)
+
+// use method on the instance 
+const message = hello.message;
+```
+
+3. Extend a class
+
+```ts
+// extend a class by first activating it with `$(Hello)`
+export class World extends $(Hello).extend({
   world: z.string()
 }) {}
 
@@ -34,6 +53,7 @@ const world = new World({
   world: "hello"
 });
 ```
+
 
 ## Why?
 
@@ -64,25 +84,3 @@ export class Person extends ZodClass({
 }
 ```
 
-## Caveats
-
-Caveat: the static `HelloSchema.parse`'s return type does not accurately reflect that it returns an instance of the created class,
-
-```ts
-const unknownValue: unknown;
-
-// we wish it was `HelloSchema`, not `{ key: string }`.
-const hello2: {
-  key: string;
-} = HelloSchema.parse(unknownValue);
-```
-
-Workaround: just cast it
-
-```ts
-// option 1
-const hello: HelloSchema = HelloSchema.parse(unknownValue);
-
-// option 2
-const hello = HelloSchema.parse<HelloSchema>(unknownValue);
-```

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The `$` utility function is the swiss army knife in `zod-class` - you use it for
 
 ```ts
 import z from "zod";
-import { $ } from "zod-class";
+import { Z } from "zod-class";
 
 // define a class using a zod schema
-export class Hello extends $({
+export class Hello extends Z({
   name: z.string(),
 }) {
   get message() {
@@ -34,7 +34,7 @@ const hello = new Hello({
 
 2. Parse a value to an instance of a ZodClass
 ```ts
-const hello = $(Hello).parse(someVal)
+const hello = Z(Hello).parse(someVal)
 
 // use method on the instance 
 const message = hello.message;
@@ -43,8 +43,8 @@ const message = hello.message;
 3. Extend a class
 
 ```ts
-// extend a class by first activating it with `$(Hello)`
-export class World extends $(Hello).extend({
+// extend a class by first activating it with `Z(Hello)`
+export class World extends Z(Hello).extend({
   world: z.string()
 }) {}
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ const world = new World({
 });
 ```
 
-
 ## Why?
 
 It can be annoying to always have redundant declarations for types and schemas:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "zod-class",
   "description": "Create classes from Zod Object schemas all in one line",
   "version": "0.0.4",
+  "repository": {
+    "url": "https://github.com/sam-goodwin/zod-class"
+  },
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,7 @@ export interface ZodClass<T extends ZodRawShape, Self = {}>
  * ```
  * @param shape
  * @returns
+ * @deprecated - use {@link $}({ shape }) instead
  */
 export function ZodClass<T extends ZodRawShape>(shape: T): ZodClass<T> {
   const _schema = object(shape);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,11 @@ export function isZodClass(a: any): a is Ctor {
   return typeof a === "function" && a[IS_ZOD_CLASS];
 }
 
-export function $<Shape extends ZodRawShape = ZodRawShape>(
+export function Z<Shape extends ZodRawShape = ZodRawShape>(
   shape: Shape
 ): ZodClass<Shape>;
 
-export function $<Super extends Ctor>(
+export function Z<Super extends Ctor>(
   Super: Super
 ): {
   parse(value: unknown): InstanceType<Super>;
@@ -34,7 +34,7 @@ export function $<Super extends Ctor>(
   ): ZodClass<Omit<Super["shape"], keyof Shape> & Shape, InstanceType<Super>>;
 };
 
-export function $(shapeOrSuper: any) {
+export function Z(shapeOrSuper: any) {
   if (isZodClass(shapeOrSuper)) {
     const Super = shapeOrSuper;
     return {
@@ -94,7 +94,7 @@ export interface ZodClass<T extends ZodRawShape, Self = {}>
  * ```
  * @param shape
  * @returns
- * @deprecated - use {@link $}({ shape }) instead
+ * @deprecated - use {@link Z}({ shape }) instead
  */
 export function ZodClass<T extends ZodRawShape>(shape: T): ZodClass<T> {
   const _schema = object(shape);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,45 +5,56 @@ import {
   ZodType,
   ParseParams,
   SafeParseReturnType,
-  z,
 } from "zod";
 
-type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) extends (
-  x: infer R
-) => any
-  ? R
-  : never;
-
-type ZodValue<T extends ZodType> = T extends ZodType<infer Output>
-  ? UnionToIntersection<Output>
-  : never;
+const IS_ZOD_CLASS = Symbol.for("zod-class");
 
 type Ctor<Shape extends ZodRawShape = ZodRawShape, Self = any> = {
+  [IS_ZOD_CLASS]: true;
   shape: Shape;
   schema: ZodObject<Shape>;
+  parse(value: unknown): Self;
   new (input: any): Self;
 };
+
+export function isZodClass(a: any): a is Ctor {
+  return typeof a === "function" && a[IS_ZOD_CLASS];
+}
+
+export function $<Shape extends ZodRawShape = ZodRawShape>(
+  shape: Shape
+): ZodClass<Shape>;
 
 export function $<Super extends Ctor>(
   Super: Super
 ): {
+  parse(value: unknown): InstanceType<Super>;
   extend<Shape extends ZodRawShape>(
     shape: Shape
   ): ZodClass<Omit<Super["shape"], keyof Shape> & Shape, InstanceType<Super>>;
-} {
-  return {
-    extend<Shape extends ZodRawShape>(augmentation: Shape) {
-      const augmented = Super.schema.extend(augmentation);
-      // @ts-ignore
-      return class extends Super {
-        static schema = augmented;
-        constructor(value: any) {
-          super(value);
-          Object.assign(this, augmented.parse(value));
-        }
-      } as any;
-    },
-  };
+};
+
+export function $(shapeOrSuper: any) {
+  if (isZodClass(shapeOrSuper)) {
+    const Super = shapeOrSuper;
+    return {
+      parse(value: unknown) {
+        return Super.parse(value) as any;
+      },
+      extend<Shape extends ZodRawShape>(augmentation: Shape) {
+        const augmented = Super.schema.extend(augmentation);
+        // @ts-ignore
+        return class extends Super {
+          static schema = augmented;
+          constructor(value: any) {
+            super(value);
+            Object.assign(this, augmented.parse(value));
+          }
+        } as any;
+      },
+    };
+  }
+  return ZodClass(shapeOrSuper);
 }
 
 export interface ZodClass<T extends ZodRawShape, Self = {}>
@@ -51,6 +62,7 @@ export interface ZodClass<T extends ZodRawShape, Self = {}>
     ZodObject<T>,
     "parse" | "parseAsync" | "safeParse" | "safeParseAsync"
   > {
+  [IS_ZOD_CLASS]: true;
   shape: T;
   schema: ZodObject<T>;
   parse<T extends InstanceType<this> = InstanceType<this>>(value: unknown): T;
@@ -86,6 +98,7 @@ export interface ZodClass<T extends ZodRawShape, Self = {}>
 export function ZodClass<T extends ZodRawShape>(shape: T): ZodClass<T> {
   const _schema = object(shape);
   return class {
+    static [IS_ZOD_CLASS]: true = true;
     static schema = _schema;
     static parse(value: unknown, params?: Partial<ParseParams>) {
       return new this(this.schema.parse(value, params) as any);
@@ -137,3 +150,13 @@ function coerceSafeParse<C extends ZodClass<any>>(
     return result;
   }
 }
+
+type UnionToIntersection<T> = (T extends any ? (x: T) => any : never) extends (
+  x: infer R
+) => any
+  ? R
+  : never;
+
+type ZodValue<T extends ZodType> = T extends ZodType<infer Output>
+  ? UnionToIntersection<Output>
+  : never;

--- a/test/zod-class.test.ts
+++ b/test/zod-class.test.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ZodClass, $ } from "../src/index.js";
+import { ZodClass, Z } from "../src/index.js";
 
 test("support extending classes", () => {
   class Foo extends ZodClass({
@@ -21,7 +21,7 @@ test("support extending classes", () => {
   expect(parsedFoo instanceof Foo).toBe(true);
   expect(foo).toMatchObject(parsedFoo);
 
-  class Bar extends $(Foo).extend({
+  class Bar extends Z(Foo).extend({
     baz: z.literal("Forty"),
   }) {
     getFoo() {
@@ -70,7 +70,7 @@ test("support extending classes", () => {
 });
 
 test("should inherit class methods", () => {
-  class Foo extends $({
+  class Foo extends Z({
     foo: z.string(),
   }) {
     getFoo() {
@@ -78,7 +78,7 @@ test("should inherit class methods", () => {
     }
   }
 
-  class Bar extends $(Foo).extend({
+  class Bar extends Z(Foo).extend({
     foo: z.literal("forty-two"),
     bar: z.number(),
   }) {
@@ -92,16 +92,16 @@ test("should inherit class methods", () => {
     bar: 42,
   };
 
-  const bar = $(Bar).parse(barSchema);
+  const bar = Z(Bar).parse(barSchema);
 
   expect(bar.getFoo()).toEqual("forty-two");
   expect(bar.getBar()).toEqual(42);
 
-  class Baz extends $(Bar).extend({
+  class Baz extends Z(Bar).extend({
     baz: z.string(),
   }) {
     getFoo() {
-      return `foo: ${super.getFoo()}`;
+      return `foo: Z{super.getFoo()}`;
     }
     getBaz() {
       return this.baz;

--- a/test/zod-class.test.ts
+++ b/test/zod-class.test.ts
@@ -70,7 +70,7 @@ test("support extending classes", () => {
 });
 
 test("should inherit class methods", () => {
-  class Foo extends ZodClass({
+  class Foo extends $({
     foo: z.string(),
   }) {
     getFoo() {
@@ -92,7 +92,7 @@ test("should inherit class methods", () => {
     bar: 42,
   };
 
-  const bar = Bar.parse<Bar>(barSchema);
+  const bar = $(Bar).parse(barSchema);
 
   expect(bar.getFoo()).toEqual("forty-two");
   expect(bar.getBar()).toEqual(42);


### PR DESCRIPTION
Closes: https://github.com/sam-goodwin/zod-class/issues/4

- [x] Add how to parse values to a zod class to dpcs
- [x] Add how to extend a class 
- [x] Overload the `Z` utility to standardize and centralize how classes are created, parsed and extended - this replaces the previous `ZodClass

The `$` utility function is the swiss army knife in `zod-class` - you use it for everything.

1. Define a new class

```ts
import z from "zod";
import { Z } from "zod-class";

// define a class using a zod schema
export class Hello extends Z({
  name: z.string(),
}) {
  get message() {
    return `hello ${name}`
  }
}

const hello = new Hello({
  hello: "sam",
});
```

2. Parse a value to an instance of a ZodClass
```ts
const hello = Z(Hello).parse(someVal)

// use method on the instance 
const message = hello.message;
```

3. Extend a class

```ts
// extend a class by first activating it with `Z(Hello)`
export class World extends Z(Hello).extend({
  world: z.string()
}) {}

const world = new World({
  hello: "world",
  world: "hello"
});
```