### PR TITLE
feat: remove need for $ helper with inferred this type in static context

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ npm install zod-class
 
 ## Usage
 
-The `Z` utility function is the swiss army knife in `zod-class` - you use it for everything.
-
 1. Define a new class
 
 ```ts
@@ -22,7 +20,7 @@ import { Z } from "zod-class";
 export class Hello extends Z.class({
   name: z.string(),
 }) {
-  get message() {
+  get getMessage() {
     return `hello ${name}`
   }
 }
@@ -34,17 +32,16 @@ const hello = new Hello({
 
 2. Parse a value to an instance of a ZodClass
 ```ts
-const hello = Z(Hello).parse(someVal)
+const hello = Hello.parse(someVal)
 
 // use method on the instance 
-const message = hello.message;
+const message = hello.getMessage();
 ```
 
 3. Extend a class
 
 ```ts
-// extend a class by first activating it with `Z(Hello)`
-export class World extends Z(Hello).extend({
+export class World extends Hello.extend({
   world: z.string()
 }) {}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zod-class",
   "description": "Create classes from Zod Object schemas all in one line",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "repository": {
     "url": "https://github.com/sam-goodwin/zod-class"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^29.5.4",
     "@types/node": "^16",
     "jest": "^29.7.0",
-    "prettier": "^2",
+    "prettier": "^2.8.8",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ devDependencies:
     specifier: ^29.7.0
     version: 29.7.0(@types/node@16.18.11)(ts-node@10.9.1)
   prettier:
-    specifier: ^2
-    version: 2.0.0
+    specifier: ^2.8.8
+    version: 2.8.8
   ts-jest:
     specifier: ^29.1.1
     version: 29.1.1(@babel/core@7.22.17)(jest@29.7.0)(typescript@5.2.2)
@@ -2032,8 +2032,8 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /prettier@2.0.0:
-    resolution: {integrity: sha512-vI55PC+GFLOVtpwr2di1mYhJF36v+kztJov8sx3AmqbfdA+2Dhozxb+3e1hTgoV9lyhnVJFF3Z8GCVeMBOS1bA==}
+  /prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,139 +5,162 @@ import {
   ZodType,
   ParseParams,
   SafeParseReturnType,
+  ZodArray,
+  ZodTuple,
+  ZodRecord,
+  ZodMap,
+  ZodSet,
+  ZodFunction,
+  ZodLazy,
+  type z,
+  ZodPromise,
+  ZodOptional,
+  ZodNullable,
 } from "zod";
 
 const IS_ZOD_CLASS = Symbol.for("zod-class");
 
-type Ctor<Shape extends ZodRawShape = ZodRawShape, Self = any> = {
-  [IS_ZOD_CLASS]: true;
-  shape: Shape;
-  schema: ZodObject<Shape>;
-  parse(value: unknown): Self;
-  new (input: any): Self;
+type Ctor<T = any> = {
+  new (input: any): T;
 };
 
-export function isZodClass(a: any): a is Ctor {
-  return typeof a === "function" && a[IS_ZOD_CLASS];
+export interface ZodClass<Properties, Instance> extends ZodType<Instance> {
+  extend<Super extends Ctor, Shape extends ZodRawShape>(
+    this: Super,
+    shape: Shape
+  ): ZodClass<
+    Z.infer<ZodObject<Shape>> & ConstructorParameters<Super>[0],
+    Z.infer<ZodObject<Shape>> & InstanceType<Super>
+  >;
+  parse<T>(this: Ctor<T>, value: unknown): T;
+  parseAsync<T>(this: Ctor<T>, value: unknown): Promise<T>;
+  safeParse<T, V>(this: Ctor<T>, value: V): SafeParseReturnType<V, T>;
+  safeParseAsync<T, V>(
+    this: Ctor<T>,
+    value: V
+  ): Promise<SafeParseReturnType<V, T>>;
+  optional<Self extends ZodType>(this: Self): ZodOptional<Self>;
+  nullable<Self extends ZodType>(this: Self): ZodNullable<Self>;
+
+  new (data: Properties): Instance;
+}
+
+type OptionalKeys<Shape> = {
+  [k in keyof Shape]: undefined extends Z.infer<Shape[k]> ? k : never;
+}[keyof Shape];
+
+export declare namespace Z {
+  export type infer<T> = T extends new (...args: any[]) => infer R
+    ? R
+    : T extends ZodObject<infer Shape>
+    ? {
+        [k in keyof Pick<
+          Shape,
+          Exclude<keyof Shape, OptionalKeys<Shape>>
+        >]: Z.infer<Shape[k]>;
+      } &
+        {
+          [k in OptionalKeys<Shape>]+?: Z.infer<Shape[k]>;
+        }
+    : T extends ZodArray<infer I>
+    ? Z.infer<I>[]
+    : T extends ZodOptional<infer T>
+    ? Z.infer<T> | undefined
+    : T extends ZodNullable<infer T>
+    ? Z.infer<T> | null
+    : T extends ZodTuple<infer T>
+    ? { [i in keyof T]: Z.infer<T[i]> }
+    : T extends ZodRecord<infer Key, infer Value>
+    ? {
+        [k in Z.infer<Key>]: Z.infer<Value>;
+      }
+    : T extends ZodMap<infer Key, infer Value>
+    ? Map<Z.infer<Key>, Z.infer<Value>>
+    : T extends ZodSet<infer Item>
+    ? Set<Z.infer<Item>>
+    : T extends ZodFunction<infer Args, infer Output>
+    ? (...args: Z.infer<Args>) => Z.infer<Output>
+    : T extends ZodLazy<infer T>
+    ? Z.infer<T>
+    : T extends ZodPromise<infer T>
+    ? Promise<Z.infer<T>>
+    : T extends ZodType<any, any, any>
+    ? z.infer<T>
+    : never;
 }
 
 export interface Z {
-  class<T extends ZodRawShape>(shape: T): ZodClass<T>;
-  <Super extends Ctor>(Super: Super): {
-    parse(value: unknown): InstanceType<Super>;
-    extend<Shape extends ZodRawShape>(
-      shape: Shape
-    ): ZodClass<Omit<Super["shape"], keyof Shape> & Shape, InstanceType<Super>>;
-  };
+  class<T extends ZodRawShape>(
+    shape: T
+  ): ZodClass<Z.infer<ZodObject<T>>, Z.infer<ZodObject<T>>>;
 }
 
-export const Z = (function <Super extends Ctor>(
-  Super: Super
-): {
-  parse(value: unknown): InstanceType<Super>;
-  extend<Shape extends ZodRawShape>(
-    shape: Shape
-  ): ZodClass<Omit<Super["shape"], keyof Shape> & Shape, InstanceType<Super>>;
-} {
-  return {
-    parse(value: unknown) {
-      return Super.parse(value) as any;
+export const Z = {
+  class<T extends ZodRawShape>(
+    shape: T
+  ): ZodClass<
+    {
+      [k in keyof T]: Z.infer<T[k]>;
     },
-    extend<Shape extends ZodRawShape>(augmentation: Shape) {
-      const augmented = Super.schema.extend(augmentation);
-      // @ts-ignore
-      return class extends Super {
-        static schema = augmented;
-        constructor(value: any) {
-          super(value);
-          Object.assign(this, augmented.parse(value));
-        }
-      } as any;
-    },
-  };
-} as any) as Z;
-
-export interface ZodClass<T extends ZodRawShape, Self = {}>
-  extends Omit<
-    ZodObject<T>,
-    "parse" | "parseAsync" | "safeParse" | "safeParseAsync"
+    Z.infer<ZodObject<T>>
   > {
-  [IS_ZOD_CLASS]: true;
-  shape: T;
-  schema: ZodObject<T>;
-  parse<T extends InstanceType<this> = InstanceType<this>>(value: unknown): T;
-  parseAsync<Output extends InstanceType<this> = InstanceType<this>>(
-    value: unknown
-  ): Promise<Output>;
-  safeParse<Output extends InstanceType<this> = InstanceType<this>>(
-    data: unknown,
-    params?: Partial<ParseParams>
-  ): SafeParseReturnType<ZodValue<ZodObject<T>>, Output>;
-  safeParseAsync<Output extends InstanceType<this> = InstanceType<this>>(
-    value: unknown
-  ): Promise<SafeParseReturnType<ZodValue<ZodObject<T>>, Output>>;
+    const _schema = object(shape);
+    const clazz = class {
+      static [IS_ZOD_CLASS]: true = true;
+      static schema = _schema;
+      static shape = shape;
 
-  new (data: ZodValue<ZodObject<T>>): Self & ZodValue<ZodObject<T>>;
-}
+      constructor(value: ZodValue<ZodObject<T>>) {
+        Object.assign(this, _schema.parse(value));
+      }
 
-/**
- * Creates a class and a Zod schema in one line.
- *
- * ```ts
- * class HelloObject extends ZodClass({
- *   key: z.string()
- * }) { }
- *
- * new HelloObject({
- *   key: "key"
- * })
- * ```
- * @param shape
- * @returns
- */
-Z["class"] = function <T extends ZodRawShape>(shape: T): ZodClass<T> {
-  const _schema = object(shape);
-  return class {
-    static [IS_ZOD_CLASS]: true = true;
-    static schema = _schema;
-    static parse(value: unknown, params?: Partial<ParseParams>) {
-      return new this(this.schema.parse(value, params) as any);
-    }
+      static extend<Shape extends ZodRawShape>(augmentation: Shape) {
+        const augmented = this.schema.extend(augmentation);
+        // @ts-ignore
+        return class extends Super {
+          static schema = augmented;
+          constructor(value: any) {
+            super(value);
+            Object.assign(this, augmented.parse(value));
+          }
+        } as any;
+      }
 
-    static parseAsync(value: unknown, params?: Partial<ParseParams>) {
-      return this.schema
-        .parseAsync(value, params)
-        .then((value) => new this(value as any));
-    }
+      static parse(value: unknown, params?: Partial<ParseParams>) {
+        return new this(this.schema.parse(value, params) as any);
+      }
 
-    static safeParse(
-      value: unknown,
-      params?: Partial<ParseParams>
-    ): SafeParseReturnType<any, any> {
-      return coerceSafeParse(
-        (this as any) as ZodClass<T>,
-        this.schema.safeParse(value, params)
-      );
-    }
+      static parseAsync(value: unknown, params?: Partial<ParseParams>) {
+        return this.schema
+          .parseAsync(value, params)
+          .then((value) => new this(value as any));
+      }
 
-    static safeParseAsync(
-      value: unknown,
-      params?: Partial<ParseParams>
-    ): Promise<SafeParseReturnType<any, any>> {
-      return this.schema
-        .safeParseAsync(value, params)
-        .then((result) =>
-          coerceSafeParse((this as any) as ZodClass<T>, result)
+      static safeParse(
+        value: unknown,
+        params?: Partial<ParseParams>
+      ): SafeParseReturnType<any, any> {
+        return coerceSafeParse(
+          this as any,
+          this.schema.safeParse(value, params)
         );
-    }
+      }
 
-    constructor(value: ZodValue<ZodObject<T>>) {
-      Object.assign(this, _schema.parse(value));
-    }
-  } as any;
+      static safeParseAsync(
+        value: unknown,
+        params?: Partial<ParseParams>
+      ): Promise<SafeParseReturnType<any, any>> {
+        return this.schema
+          .safeParseAsync(value, params)
+          .then((result) => coerceSafeParse(this as any, result));
+      }
+    };
+    Object.assign(clazz, _schema);
+    return clazz as any;
+  },
 };
 
-function coerceSafeParse<C extends ZodClass<any>>(
+function coerceSafeParse<C extends ZodClass<any, any>>(
   clazz: C,
   result: SafeParseReturnType<any, any>
 ): SafeParseReturnType<any, InstanceType<C>> {

--- a/test/zod-class.test.ts
+++ b/test/zod-class.test.ts
@@ -107,7 +107,7 @@ test("should inherit class methods", () => {
     baz: z.string(),
   }) {
     getFoo() {
-      return `foo: Z{super.getFoo()}`;
+      return `foo: ${super.getFoo()}`;
     }
     getBaz() {
       return this.baz;
@@ -151,10 +151,32 @@ test("should support classes as properties in an object", () => {
     Baz,
     Bar: Bar.optional(),
     bar: Bar.nullable(),
+    barNullableOptional: Bar.nullable().optional(),
+    barOptionalNullable: Bar.optional().nullable(),
   });
   type XYZ = Z.infer<typeof XYZ>;
   const xyz: XYZ = {
     bar,
     Baz: baz,
   };
+});
+
+test("static methods should be inherited", () => {
+  class Foo extends Z.class({
+    foo: z.string(),
+  }) {
+    static GetFoo() {
+      return "foo";
+    }
+  }
+  class Bar extends Foo.extend({
+    bar: z.number(),
+  }) {
+    static GetBar() {
+      return 42;
+    }
+  }
+
+  expect(Bar.GetFoo()).toEqual("foo");
+  expect(Bar.GetBar()).toEqual(42);
 });

--- a/test/zod-class.test.ts
+++ b/test/zod-class.test.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { ZodRawShape, z } from "zod";
 import { Z } from "../src/index.js";
 
 test("support extending classes", () => {
@@ -13,7 +13,8 @@ test("support extending classes", () => {
     bar: 1,
     baz: "Two",
   });
-  const parsedFoo = Foo.parse<Foo>({
+
+  const parsedFoo = Foo.parse({
     foo: "foo",
     bar: 1,
     baz: "Two",
@@ -21,7 +22,7 @@ test("support extending classes", () => {
   expect(parsedFoo instanceof Foo).toBe(true);
   expect(foo).toMatchObject(parsedFoo);
 
-  class Bar extends Z(Foo).extend({
+  class Bar extends Foo.extend({
     baz: z.literal("Forty"),
   }) {
     getFoo() {
@@ -55,7 +56,7 @@ test("support extending classes", () => {
   });
 
   expect(bar instanceof Bar).toBe(true);
-  const parsedBar = Bar.parse<Bar>({
+  const parsedBar = Bar.parse({
     foo: "foo",
     bar: 1,
     baz: "Forty",
@@ -78,7 +79,7 @@ test("should inherit class methods", () => {
     }
   }
 
-  class Bar extends Z(Foo).extend({
+  class Bar extends Foo.extend({
     foo: z.literal("forty-two"),
     bar: z.number(),
   }) {
@@ -87,17 +88,22 @@ test("should inherit class methods", () => {
     }
   }
 
+  const B = Foo.extend({
+    foo: z.literal("forty-two"),
+    bar: z.number(),
+  });
+
   const barSchema = {
     foo: "forty-two",
     bar: 42,
   };
 
-  const bar = Z(Bar).parse(barSchema);
+  const bar = Bar.parse(barSchema);
 
   expect(bar.getFoo()).toEqual("forty-two");
   expect(bar.getBar()).toEqual(42);
 
-  class Baz extends Z(Bar).extend({
+  class Baz extends Bar.extend({
     baz: z.string(),
   }) {
     getFoo() {
@@ -116,4 +122,39 @@ test("should inherit class methods", () => {
 
   expect(baz.getFoo()).toEqual("foo: forty-two");
   expect(baz.getBaz()).toEqual("baz");
+});
+
+test("should support classes as properties in an object", () => {
+  class Foo extends Z.class({
+    foo: z.string(),
+  }) {}
+
+  class Bar extends Z.class({
+    Foo,
+    list: z.array(Foo),
+  }) {}
+
+  const bar = new Bar({
+    Foo: new Foo({ foo: "foo" }),
+    list: [new Foo({ foo: "foo" })],
+  });
+
+  class Baz extends Z.class({
+    foobar: z.tuple([Foo, Bar]),
+  }) {}
+
+  const baz = new Baz({
+    foobar: [new Foo({ foo: "foo" }), bar],
+  });
+
+  const XYZ = z.object({
+    Baz,
+    Bar: Bar.optional(),
+    bar: Bar.nullable(),
+  });
+  type XYZ = Z.infer<typeof XYZ>;
+  const xyz: XYZ = {
+    bar,
+    Baz: baz,
+  };
 });


### PR DESCRIPTION
A recent discovery from @ssalbdivad makes it possible to remove the `$(Foo)` utility.

Solid thread detailing it here: https://x.com/ssalbdivad/status/1714789074077204934?s=20

Basically, we can now infer `this` in a static context which allows us to bind to a generated type `Foo` within a `static parse` context.

```ts
parse<T>(this: Ctor<T>, value: unknown): T;
```

- [x] This change removes the `$` utility in favor of this simpler, more idiomatic method:
```ts
export class Foo extends Z.class({
  foo: z.string()
}) {}

export class Bar extends Foo.extend({
  bar: z.string()
}) {}

// bar is of type Bar, YAY! 🚀
const bar = Bar.parse({ foo: "foo", bar: "bar"});
```

- [x] I also decided to implement my own `Z.infer` method so that Zod Classes can be used as the types in other schemas.
```ts
export class Baz extends Z.class({
  foo: Foo
}) {}
```

- [x] update README.md