### PR TITLE
feat: expose a ZodClass's schema for reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ const HelloSchema = z.object({
 
 `zod-class` enables this to be achieved in a single line.
 
+It also provides a class that can be instantiated and methods added to.
+
 ```ts
 export class Person extends Z.class({
   firstName: z.string(),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zod-class
 
-This is a small utility library to accompany [Zod](https://github.com/colinhacks/zod) to enable for Types and Schemas to be defined in one line by creating a Class.
+This is a small utility library to accompany [Zod](https://github.com/colinhacks/zod) that enables Types and Schemas to be defined in one line by creating a Class.
 
 ## Installation
 
@@ -51,6 +51,26 @@ const world = new World({
 });
 ```
 
+4. Access A ZodClass's property to re-use in other schemas
+
+```ts
+import { z } from "zod";
+import { Z } from "zod-class";
+
+export class Product extends Z.class({
+  id: z.string().brand<"ProductId">,
+  price: z.number().min(1)
+}) {}
+
+export class Order extends Z.class({
+  id: z.string().brand<"OrderId">,
+  productId: Product.shape.id // 👈 Re-using the branded type `id` from `Product` class 
+}) {}
+
+
+Product.Id // 👈 Properties are also available in friendly pascal case directly on the class constructor
+```
+
 ## Why?
 
 It can be annoying to always have redundant declarations for types and schemas:
@@ -66,8 +86,6 @@ const HelloSchema = z.object({
 ```
 
 `zod-class` enables this to be achieved in a single line.
-
-It also provides a class that can be instantiated and methods added to.
 
 ```ts
 export class Person extends Z.class({

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
     "zod": "3.20.2"
+  },
+  "dependencies": {
+    "type-fest": "^4.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,10 @@
 lockfileVersion: '6.0'
 
+dependencies:
+  type-fest:
+    specifier: ^4.6.0
+    version: 4.6.0
+
 devDependencies:
   '@tsconfig/node16':
     specifier: ^1.0.3
@@ -2319,6 +2324,11 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
     dev: true
+
+  /type-fest@4.6.0:
+    resolution: {integrity: sha512-rLjWJzQFOq4xw7MgJrCZ6T1jIOvvYElXT12r+y0CC6u67hegDHaxcPqb2fZHOGlqxugGQPNB1EnTezjBetkwkw==}
+    engines: {node: '>=16'}
+    dev: false
 
   /typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export declare namespace Z {
         [k in Z.infer<Key>]: Z.infer<Value>;
       }
     : T extends ZodMap<infer Key, infer Value>
-    ? [T, Map<Z.infer<Key>, Z.infer<Value>>]
+    ? Map<Z.infer<Key>, Z.infer<Value>>
     : T extends ZodSet<infer Item>
     ? Set<Z.infer<Item>>
     : T extends ZodFunction<infer Args, infer Output>

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,6 @@ export interface ZodClass<Members, Instance, Shape extends ZodRawShape>
       Z.infer<ZodObject<ChildShape>> & ConstructorParameters<Super>[0],
       Z.infer<ZodObject<ChildShape>> & InstanceType<Super>,
       Omit<Shape, keyof ChildShape> & ChildShape
-      // {
-      //   [k in keyof Super]: Super[k];
-      // }
     >;
   parse<T>(this: Ctor<T>, value: unknown): T;
   parseAsync<T>(this: Ctor<T>, value: unknown): Promise<T>;
@@ -121,7 +118,6 @@ export const Z = {
     },
     Z.infer<ZodObject<T>>,
     T
-    // {}
   > {
     const _schema = object(shape);
     const clazz = class {

--- a/src/to-pascal-case.ts
+++ b/src/to-pascal-case.ts
@@ -1,0 +1,10 @@
+export function toPascalCase(str: string): string {
+  return (
+    str
+      // Split on non-word characters, underscores, spaces, or boundaries between a lower-case letter and an upper-case letter, or a number and a letter
+      .split(/\W|_|\s+|(?<=[a-z])(?=[A-Z])|(?<=[0-9])(?=[A-Za-z])/)
+      // Capitalize the first letter of each word and join them together
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join("")
+  );
+}

--- a/test/to-pascal-case.test.ts
+++ b/test/to-pascal-case.test.ts
@@ -1,0 +1,54 @@
+import { toPascalCase } from "../src/to-pascal-case.js";
+
+describe("toPascalCase", () => {
+  it("should handle single word property names", () => {
+    expect(toPascalCase("id")).toBe("Id");
+    expect(toPascalCase("product")).toBe("Product");
+  });
+
+  it("should handle camelCase property names", () => {
+    expect(toPascalCase("productId")).toBe("ProductId");
+    expect(toPascalCase("isAvailable")).toBe("IsAvailable");
+    expect(toPascalCase("orderCount")).toBe("OrderCount");
+  });
+
+  it("should handle snake_case property names", () => {
+    expect(toPascalCase("product_id")).toBe("ProductId");
+    expect(toPascalCase("is_available")).toBe("IsAvailable");
+    expect(toPascalCase("order_count")).toBe("OrderCount");
+  });
+
+  it("should handle property names with numbers", () => {
+    expect(toPascalCase("product1")).toBe("Product1");
+    expect(toPascalCase("order2Count")).toBe("Order2Count");
+    expect(toPascalCase("product_3_id")).toBe("Product3Id");
+  });
+
+  it("should convert regular words to PascalCase", () => {
+    expect(toPascalCase("hello world")).toBe("HelloWorld");
+  });
+
+  it("should handle uppercase words", () => {
+    expect(toPascalCase("HELLO WORLD")).toBe("HelloWorld");
+  });
+
+  it("should handle underscores", () => {
+    expect(toPascalCase("hello_world")).toBe("HelloWorld");
+  });
+
+  it("should handle hyphens", () => {
+    expect(toPascalCase("hello-world")).toBe("HelloWorld");
+  });
+
+  it("should handle multiple non-word characters", () => {
+    expect(toPascalCase("hello--world__example")).toBe("HelloWorldExample");
+  });
+
+  it("should handle leading and trailing spaces", () => {
+    expect(toPascalCase(" hello world ")).toBe("HelloWorld");
+  });
+
+  it("should handle empty strings", () => {
+    expect(toPascalCase("")).toBe("");
+  });
+});

--- a/test/zod-class.test.ts
+++ b/test/zod-class.test.ts
@@ -238,3 +238,33 @@ test("static properties should plumb through", () => {
   expect(Bar.Id.parse("b")).toEqual("b");
   expect(Bar.Bar.parse(42)).toEqual(42);
 });
+
+test("map type", () => {
+  class Foo extends Z.class({
+    map: z.map(z.string(), z.number()),
+  }) {}
+
+  new Foo({
+    map: new Map<string, number>(),
+  });
+  new Foo({
+    // @ts-expect-error
+    map: new Map<number, number>(),
+  });
+  new Foo({
+    // @ts-expect-error
+    map: new Map<string, string>(),
+  });
+
+  const foo = new Foo({
+    map: new Map([["", 2]]),
+  });
+
+  expect(foo.map.get("")).toEqual(2);
+
+  const map: Map<string, number> = foo.map;
+  // @ts-expect-error
+  const map2: Map<number, number> = foo.map;
+  // @ts-expect-error
+  const map3: Map<string, string> = foo.map;
+});

--- a/test/zod-class.test.ts
+++ b/test/zod-class.test.ts
@@ -31,7 +31,7 @@ test("support extending classes", () => {
     getBar() {
       return this.bar;
     }
-    getBaz() {
+    getBaz(): this["baz"] {
       return this.baz;
     }
   }
@@ -133,6 +133,7 @@ test("should support classes as properties in an object", () => {
     Foo,
     list: z.array(Foo),
   }) {}
+  Bar.shape.list;
 
   const bar = new Bar({
     Foo: new Foo({ foo: "foo" }),
@@ -179,4 +180,61 @@ test("static methods should be inherited", () => {
 
   expect(Bar.GetFoo()).toEqual("foo");
   expect(Bar.GetBar()).toEqual(42);
+});
+
+// see: https://github.com/sam-goodwin/zod-class/issues/14
+test("should be able to reference a ZodClass's property schemas", () => {
+  class Product extends Z.class({
+    id: z.string().brand("ProductId"),
+    price: z.number().min(1),
+  }) {}
+
+  class Order extends Z.class({
+    id: z.string().brand("OrderId"),
+    productId: Product.shape.id, // 👈 Re-using the branded type `id` from `Product` class
+  }) {
+    public getMessage() {
+      return [this.id, this.productId];
+    }
+  }
+
+  const o1 = new Order({
+    // @ts-expect-error
+    id: "1",
+    // @ts-expect-error
+    productId: "2",
+  });
+  expect(o1.getMessage()).toEqual(["1", "2"]);
+
+  const o2 = new Order({
+    id: Order.shape.id.parse("3"),
+    productId: Order.shape.productId.parse("4"),
+  });
+
+  expect(o2.getMessage()).toEqual(["3", "4"]);
+
+  // nice auto-type alias for the typeof Order.Id
+  type OrderID = typeof Order.Id;
+
+  const o3 = new Order({
+    id: Order.Id.parse("5"),
+    productId: Order.ProductId.parse("6"),
+  });
+
+  expect(o3.getMessage()).toEqual(["5", "6"]);
+});
+
+test("static properties should plumb through", () => {
+  class Foo extends Z.class({
+    id: z.string(),
+  }) {}
+  class Bar extends Foo.extend({
+    bar: z.number(),
+  }) {}
+
+  Foo.Id;
+  Bar.Id;
+  expect(Foo.Id.parse("a")).toEqual("a");
+  expect(Bar.Id.parse("b")).toEqual("b");
+  expect(Bar.Bar.parse(42)).toEqual(42);
 });


### PR DESCRIPTION
Closes https://github.com/sam-goodwin/zod-class/issues/14

- [x] Add the `.shape` property back to a ZodClass so that it can be referenced

```ts
import { z } from "zod";
import { Z } from "zod-class";

export class Product extends Z.class({
  id: z.string().brand<"ProductId">,
  price: z.number().min(1)
}) {}
```

- [x] (experiment): lift the schema's properties to the top-level and convert to `PascalCase`

```ts
export class Order extends Z.class({
  id: z.string().brand<"OrderId">,
  productId: Product.Id // 👈 Properties are also available in friendly pascal case directly on the class constructor
}) {}
```