### PR TITLE
feat: additional methods, expose schema and fix union bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/node_modules
-/lib
+node_modules
+lib
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 .idea
+*.tsbuildinfo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,6 @@
   "eslint.format.enable": false,
   "prettier.prettierPath": "./node_modules/prettier",
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.preferences.importModuleSpecifier": "relative"
+  "typescript.preferences.importModuleSpecifier": "relative",
+  "cSpell.words": ["clazz"]
 }

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ const HelloSchema = z.object({
 
 `zod-class` enables this to be achieved in a single line.
 
+It also provides a class that can be instantiated and methods added to.
+
 ```ts
 export class Person extends Z.class({
   firstName: z.string(),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zod-class
 
-This is a small utility library to accompany [Zod](https://github.com/colinhacks/zod) to enable for Types and Schemas to be defined in one line by creating a Class.
+This is a small utility library to accompany [Zod](https://github.com/colinhacks/zod) that enables Types and Schemas to be defined in one line by creating a Class.
 
 ## Installation
 
@@ -51,6 +51,26 @@ const world = new World({
 });
 ```
 
+4. Access A ZodClass's property to re-use in other schemas
+
+```ts
+import { z } from "zod";
+import { Z } from "zod-class";
+
+export class Product extends Z.class({
+  id: z.string().brand<"ProductId">,
+  price: z.number().min(1)
+}) {}
+
+export class Order extends Z.class({
+  id: z.string().brand<"OrderId">,
+  productId: Product.shape.id // 👈 Re-using the branded type `id` from `Product` class 
+}) {}
+
+
+Product.Id // 👈 Properties are also available in friendly pascal case directly on the class constructor
+```
+
 ## Why?
 
 It can be annoying to always have redundant declarations for types and schemas:
@@ -66,8 +86,6 @@ const HelloSchema = z.object({
 ```
 
 `zod-class` enables this to be achieved in a single line.
-
-It also provides a class that can be instantiated and methods added to.
 
 ```ts
 export class Person extends Z.class({

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zod-class",
   "description": "Create classes from Zod Object schemas all in one line",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "repository": {
     "url": "https://github.com/sam-goodwin/zod-class"
   },
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "tsc -b",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest && cd ./test/pkg && pnpm i && pnpm build",
     "watch": "tsc -b -w"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
     "zod": "3.20.2"
+  },
+  "dependencies": {
+    "type-fest": "^4.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,10 @@
 lockfileVersion: '6.0'
 
+dependencies:
+  type-fest:
+    specifier: ^4.6.0
+    version: 4.6.0
+
 devDependencies:
   '@tsconfig/node16':
     specifier: ^1.0.3
@@ -2319,6 +2324,11 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
     dev: true
+
+  /type-fest@4.6.0:
+    resolution: {integrity: sha512-rLjWJzQFOq4xw7MgJrCZ6T1jIOvvYElXT12r+y0CC6u67hegDHaxcPqb2fZHOGlqxugGQPNB1EnTezjBetkwkw==}
+    engines: {node: '>=16'}
+    dev: false
 
   /typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export declare namespace Z {
         [k in Z.infer<Key>]: Z.infer<Value>;
       }
     : T extends ZodMap<infer Key, infer Value>
-    ? [T, Map<Z.infer<Key>, Z.infer<Value>>]
+    ? Map<Z.infer<Key>, Z.infer<Value>>
     : T extends ZodSet<infer Item>
     ? Set<Z.infer<Item>>
     : T extends ZodFunction<infer Args, infer Output>

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,6 @@ export interface ZodClass<Members, Instance, Shape extends ZodRawShape>
       Z.infer<ZodObject<ChildShape>> & ConstructorParameters<Super>[0],
       Z.infer<ZodObject<ChildShape>> & InstanceType<Super>,
       Omit<Shape, keyof ChildShape> & ChildShape
-      // {
-      //   [k in keyof Super]: Super[k];
-      // }
     >;
   parse<T>(this: Ctor<T>, value: unknown): T;
   parseAsync<T>(this: Ctor<T>, value: unknown): Promise<T>;
@@ -121,7 +118,6 @@ export const Z = {
     },
     Z.infer<ZodObject<T>>,
     T
-    // {}
   > {
     const _schema = object(shape);
     const clazz = class {

--- a/src/to-pascal-case.ts
+++ b/src/to-pascal-case.ts
@@ -1,0 +1,10 @@
+export function toPascalCase(str: string): string {
+  return (
+    str
+      // Split on non-word characters, underscores, spaces, or boundaries between a lower-case letter and an upper-case letter, or a number and a letter
+      .split(/\W|_|\s+|(?<=[a-z])(?=[A-Z])|(?<=[0-9])(?=[A-Za-z])/)
+      // Capitalize the first letter of each word and join them together
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join("")
+  );
+}

--- a/test/pkg/package.json
+++ b/test/pkg/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "test-pkg",
+  "private": true,
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "zod": "^3.22.4",
+    "zod-class": "file:../../"
+  }
+}

--- a/test/pkg/pnpm-lock.yaml
+++ b/test/pkg/pnpm-lock.yaml
@@ -1,0 +1,35 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
+  zod-class:
+    specifier: file:../../
+    version: file:../..(zod@3.22.4)
+
+packages:
+
+  /type-fest@4.7.1:
+    resolution: {integrity: sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==}
+    engines: {node: '>=16'}
+    dev: false
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false
+
+  file:../..(zod@3.22.4):
+    resolution: {directory: ../.., type: directory}
+    id: file:../..
+    name: zod-class
+    peerDependencies:
+      zod: ^3
+    dependencies:
+      type-fest: 4.7.1
+      zod: 3.22.4
+    dev: false

--- a/test/pkg/src/index.ts
+++ b/test/pkg/src/index.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+import { Z } from "zod-class";
+
+class User extends Z.class({
+  name: z.string(),
+  age: z.number(),
+}) {
+  getName() {
+    return this.name;
+  }
+}
+
+const user = User.parse({ name: "John", age: 20 });
+
+user.getName();

--- a/test/pkg/tsconfig.json
+++ b/test/pkg/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "lib",
+    "alwaysStrict": true,
+    "baseUrl": ".",
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "target": "ES2021",
+    "types": ["@types/node", "@types/jest"]
+  }
+}

--- a/test/to-pascal-case.test.ts
+++ b/test/to-pascal-case.test.ts
@@ -1,0 +1,54 @@
+import { toPascalCase } from "../src/to-pascal-case.js";
+
+describe("toPascalCase", () => {
+  it("should handle single word property names", () => {
+    expect(toPascalCase("id")).toBe("Id");
+    expect(toPascalCase("product")).toBe("Product");
+  });
+
+  it("should handle camelCase property names", () => {
+    expect(toPascalCase("productId")).toBe("ProductId");
+    expect(toPascalCase("isAvailable")).toBe("IsAvailable");
+    expect(toPascalCase("orderCount")).toBe("OrderCount");
+  });
+
+  it("should handle snake_case property names", () => {
+    expect(toPascalCase("product_id")).toBe("ProductId");
+    expect(toPascalCase("is_available")).toBe("IsAvailable");
+    expect(toPascalCase("order_count")).toBe("OrderCount");
+  });
+
+  it("should handle property names with numbers", () => {
+    expect(toPascalCase("product1")).toBe("Product1");
+    expect(toPascalCase("order2Count")).toBe("Order2Count");
+    expect(toPascalCase("product_3_id")).toBe("Product3Id");
+  });
+
+  it("should convert regular words to PascalCase", () => {
+    expect(toPascalCase("hello world")).toBe("HelloWorld");
+  });
+
+  it("should handle uppercase words", () => {
+    expect(toPascalCase("HELLO WORLD")).toBe("HelloWorld");
+  });
+
+  it("should handle underscores", () => {
+    expect(toPascalCase("hello_world")).toBe("HelloWorld");
+  });
+
+  it("should handle hyphens", () => {
+    expect(toPascalCase("hello-world")).toBe("HelloWorld");
+  });
+
+  it("should handle multiple non-word characters", () => {
+    expect(toPascalCase("hello--world__example")).toBe("HelloWorldExample");
+  });
+
+  it("should handle leading and trailing spaces", () => {
+    expect(toPascalCase(" hello world ")).toBe("HelloWorld");
+  });
+
+  it("should handle empty strings", () => {
+    expect(toPascalCase("")).toBe("");
+  });
+});

--- a/test/zod-class.test.ts
+++ b/test/zod-class.test.ts
@@ -238,3 +238,33 @@ test("static properties should plumb through", () => {
   expect(Bar.Id.parse("b")).toEqual("b");
   expect(Bar.Bar.parse(42)).toEqual(42);
 });
+
+test("map type", () => {
+  class Foo extends Z.class({
+    map: z.map(z.string(), z.number()),
+  }) {}
+
+  new Foo({
+    map: new Map<string, number>(),
+  });
+  new Foo({
+    // @ts-expect-error
+    map: new Map<number, number>(),
+  });
+  new Foo({
+    // @ts-expect-error
+    map: new Map<string, string>(),
+  });
+
+  const foo = new Foo({
+    map: new Map([["", 2]]),
+  });
+
+  expect(foo.map.get("")).toEqual(2);
+
+  const map: Map<string, number> = foo.map;
+  // @ts-expect-error
+  const map2: Map<number, number> = foo.map;
+  // @ts-expect-error
+  const map3: Map<string, string> = foo.map;
+});

--- a/test/zod-class.test.ts
+++ b/test/zod-class.test.ts
@@ -108,7 +108,6 @@ test("should inherit class methods", () => {
       return this.baz;
     }
   }
-
   const baz = new Baz({
     bar: 42,
     foo: "forty-two",
@@ -150,6 +149,7 @@ test("should support classes as properties in an object", () => {
     barNullableOptional: Bar.nullable().optional(),
     barOptionalNullable: Bar.optional().nullable(),
   });
+
   type XYZ = Z.infer<typeof XYZ>;
   const xyz: XYZ = {
     bar,

--- a/test/zod-class.test.ts
+++ b/test/zod-class.test.ts
@@ -31,7 +31,7 @@ test("support extending classes", () => {
     getBar() {
       return this.bar;
     }
-    getBaz() {
+    getBaz(): this["baz"] {
       return this.baz;
     }
   }
@@ -133,6 +133,7 @@ test("should support classes as properties in an object", () => {
     Foo,
     list: z.array(Foo),
   }) {}
+  Bar.shape.list;
 
   const bar = new Bar({
     Foo: new Foo({ foo: "foo" }),
@@ -179,4 +180,61 @@ test("static methods should be inherited", () => {
 
   expect(Bar.GetFoo()).toEqual("foo");
   expect(Bar.GetBar()).toEqual(42);
+});
+
+// see: https://github.com/sam-goodwin/zod-class/issues/14
+test("should be able to reference a ZodClass's property schemas", () => {
+  class Product extends Z.class({
+    id: z.string().brand("ProductId"),
+    price: z.number().min(1),
+  }) {}
+
+  class Order extends Z.class({
+    id: z.string().brand("OrderId"),
+    productId: Product.shape.id, // 👈 Re-using the branded type `id` from `Product` class
+  }) {
+    public getMessage() {
+      return [this.id, this.productId];
+    }
+  }
+
+  const o1 = new Order({
+    // @ts-expect-error
+    id: "1",
+    // @ts-expect-error
+    productId: "2",
+  });
+  expect(o1.getMessage()).toEqual(["1", "2"]);
+
+  const o2 = new Order({
+    id: Order.shape.id.parse("3"),
+    productId: Order.shape.productId.parse("4"),
+  });
+
+  expect(o2.getMessage()).toEqual(["3", "4"]);
+
+  // nice auto-type alias for the typeof Order.Id
+  type OrderID = typeof Order.Id;
+
+  const o3 = new Order({
+    id: Order.Id.parse("5"),
+    productId: Order.ProductId.parse("6"),
+  });
+
+  expect(o3.getMessage()).toEqual(["5", "6"]);
+});
+
+test("static properties should plumb through", () => {
+  class Foo extends Z.class({
+    id: z.string(),
+  }) {}
+  class Bar extends Foo.extend({
+    bar: z.number(),
+  }) {}
+
+  Foo.Id;
+  Bar.Id;
+  expect(Foo.Id.parse("a")).toEqual("a");
+  expect(Bar.Id.parse("b")).toEqual("b");
+  expect(Bar.Bar.parse(42)).toEqual(42);
 });


### PR DESCRIPTION
Closes https://github.com/sam-goodwin/zod-class/issues/13
Closes https://github.com/sam-goodwin/zod-class/issues/17
Closes https://github.com/sam-goodwin/zod-class/issues/18

TODO:
- [ ] For some reason, adding `nullish` to `ZodClass` breaks the types when importing from another package. Some weird behavior (zod is truly a poorly implemented library - much bloated 🫃, much spaghetti 🍝).