### PR TITLE
fix: optional fields are not required and fix stack overflow on extend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build-and-test:
@@ -20,4 +20,4 @@ jobs:
     - name: Test
       run: pnpm run test
     - name: Compile tests
-      run: pnpm run tsc --project tsconfig.test.json
+      run: pnpm tsc --project tsconfig.test.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '20'
+    - name: Install pnpm
+      run: npm install -g pnpm
+    - name: Install dependencies
+      run: pnpm install
+    - name: Build
+      run: pnpm run build
+    - name: Test
+      run: pnpm run test
+    - name: Compile tests
+      run: pnpm run tsc --project tsconfig.test.json

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest && cd ./test/pkg && pnpm i && pnpm build",
     "watch": "tsc -b -w"
   },
+  "dependencies": {
+    "type-fest": "^4.14.0"
+  },
   "peerDependencies": {
     "zod": "^3"
   },
@@ -28,14 +31,12 @@
     "@tsconfig/node16": "^1.0.3",
     "@types/jest": "^29.5.4",
     "@types/node": "^16",
+    "bun": "^1.0.36",
     "jest": "^29.7.0",
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.2",
+    "typescript": "^5.4.3",
     "zod": "3.20.2"
-  },
-  "dependencies": {
-    "type-fest": "^4.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,13 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   type-fest:
-    specifier: ^4.6.0
-    version: 4.6.0
+    specifier: ^4.14.0
+    version: 4.14.0
 
 devDependencies:
   '@tsconfig/node16':
@@ -15,6 +19,9 @@ devDependencies:
   '@types/node':
     specifier: ^16
     version: 16.18.11
+  bun:
+    specifier: ^1.0.36
+    version: 1.0.36
   jest:
     specifier: ^29.7.0
     version: 29.7.0(@types/node@16.18.11)(ts-node@10.9.1)
@@ -23,13 +30,13 @@ devDependencies:
     version: 2.8.8
   ts-jest:
     specifier: ^29.1.1
-    version: 29.1.1(@babel/core@7.22.17)(jest@29.7.0)(typescript@5.2.2)
+    version: 29.1.1(@babel/core@7.22.17)(jest@29.7.0)(typescript@5.4.3)
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.1(@types/node@16.18.11)(typescript@5.2.2)
+    version: 10.9.1(@types/node@16.18.11)(typescript@5.4.3)
   typescript:
-    specifier: ^5.2.2
-    version: 5.2.2
+    specifier: ^5.4.3
+    version: 5.4.3
   zod:
     specifier: 3.20.2
     version: 3.20.2
@@ -647,6 +654,54 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
+  /@oven/bun-darwin-aarch64@1.0.36:
+    resolution: {integrity: sha512-w4PkIgM0E4s93l+sT3UuAHA+D9WYl8YQA+hiUSU9qaIHxkAvFXf7+/mbWJ2ltlr9vOefAoJWNXMlDQNFljj6aQ==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oven/bun-darwin-x64-baseline@1.0.36:
+    resolution: {integrity: sha512-JAwk3erMgnC9l0Tn5eRSHFexkjisZDBCpAFzO1kqzIDVaq6uUC1tA38He4x6tKAsqSWghh+2b8ryA9SsJljt5w==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oven/bun-darwin-x64@1.0.36:
+    resolution: {integrity: sha512-D7PiEEswWbdYKyJTiU+ENrdvtQ5NwKFVzOIjljDgIZXx/tBVsASFXuREyFeicSGQexr77oUuN0m0zlB3okYiQg==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oven/bun-linux-aarch64@1.0.36:
+    resolution: {integrity: sha512-GeWtoSfTfSNyvlhWJ4NHZcGGe7nX8nHzCovV+c2Mk5A2UmnBYYFewq3sRT9ET6m+yMGf9qDLhgqmm5XjWjmKCA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oven/bun-linux-x64-baseline@1.0.36:
+    resolution: {integrity: sha512-G+erHwcV/ndaCHVkqF8tgwatlk1pohMjeOK+3zxgp/UEMAT9Bbt7dSPHwOdD0BRMcA9ytxLoGVfFZWqXEhR9dA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oven/bun-linux-x64@1.0.36:
+    resolution: {integrity: sha512-swLgGuUKDcoDzIf8YQmK8ewGUaHDJwIQ8o7hXA7GWZGmFSfbY6UM4no99uztuT6BXPY3AboE7Hc8sdP91T1tVQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
@@ -931,6 +986,21 @@ packages:
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
+
+  /bun@1.0.36:
+    resolution: {integrity: sha512-GUCWqouaaKf85KZLJwk27+12/55x857YVo6KGCM+ohKlzoJ6AtCea8/kDS16HoMOZ9/XKvyP3Cc+ZXUFYwoKjA==}
+    cpu: [arm64, x64]
+    os: [darwin, linux]
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@oven/bun-darwin-aarch64': 1.0.36
+      '@oven/bun-darwin-x64': 1.0.36
+      '@oven/bun-darwin-x64-baseline': 1.0.36
+      '@oven/bun-linux-aarch64': 1.0.36
+      '@oven/bun-linux-x64': 1.0.36
+      '@oven/bun-linux-x64-baseline': 1.0.36
     dev: true
 
   /callsites@3.1.0:
@@ -1504,7 +1574,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@16.18.11)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@16.18.11)(typescript@5.4.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -2250,7 +2320,7 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /ts-jest@29.1.1(@babel/core@7.22.17)(jest@29.7.0)(typescript@5.2.2):
+  /ts-jest@29.1.1(@babel/core@7.22.17)(jest@29.7.0)(typescript@5.4.3):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -2280,11 +2350,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
-      typescript: 5.2.2
+      typescript: 5.4.3
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-node@10.9.1(@types/node@16.18.11)(typescript@5.2.2):
+  /ts-node@10.9.1(@types/node@16.18.11)(typescript@5.4.3):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -2310,7 +2380,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.2.2
+      typescript: 5.4.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -2325,13 +2395,13 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /type-fest@4.6.0:
-    resolution: {integrity: sha512-rLjWJzQFOq4xw7MgJrCZ6T1jIOvvYElXT12r+y0CC6u67hegDHaxcPqb2fZHOGlqxugGQPNB1EnTezjBetkwkw==}
+  /type-fest@4.14.0:
+    resolution: {integrity: sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==}
     engines: {node: '>=16'}
     dev: false
 
-  /typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+  /typescript@5.4.3:
+    resolution: {integrity: sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/test/pkg/pnpm-lock.yaml
+++ b/test/pkg/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
 
 packages:
 
-  /type-fest@4.7.1:
-    resolution: {integrity: sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==}
+  /type-fest@4.14.0:
+    resolution: {integrity: sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==}
     engines: {node: '>=16'}
     dev: false
 
@@ -30,6 +30,6 @@ packages:
     peerDependencies:
       zod: ^3
     dependencies:
-      type-fest: 4.7.1
+      type-fest: 4.14.0
       zod: 3.22.4
     dev: false

--- a/test/pkg/src/index.ts
+++ b/test/pkg/src/index.ts
@@ -4,6 +4,7 @@ import { Z } from "zod-class";
 class User extends Z.class({
   name: z.string(),
   age: z.number(),
+  dob: z.date().optional()
 }) {
   getName() {
     return this.name;
@@ -13,3 +14,14 @@ class User extends Z.class({
 const user = User.parse({ name: "John", age: 20 });
 
 user.getName();
+
+new User({
+  name: "John",
+  age: 20,
+});
+
+new User({
+  name: "John",
+  age: 20,
+  dob: new Date(),
+});

--- a/test/zod-class.test.ts
+++ b/test/zod-class.test.ts
@@ -165,6 +165,7 @@ test("static methods should be inherited", () => {
       return "foo";
     }
   }
+
   class Bar extends Foo.extend({
     bar: z.number(),
   }) {
@@ -226,6 +227,9 @@ test("static properties should plumb through", () => {
   class Bar extends Foo.extend({
     bar: z.number(),
   }) {}
+  Foo.staticProps
+
+  // type Keys = A extends (new (...args: any[]) => any) & infer Rest ? keyof Rest : never;
 
   Foo.Id;
   Bar.Id;
@@ -455,3 +459,13 @@ test("z.union([User, Person])", () => {
   expect(user).toBeInstanceOf(User);
   expect(person).toBeInstanceOf(Person);
 });
+
+test("optional object fields are optional", () => {
+  // see: https://github.com/sam-goodwin/zod-class/issues/22
+  class drat extends Z.class({
+    foo: z.string().optional(),
+  }) {}
+
+  const ab = {};
+  new drat(ab); 
+})

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig-base.json",
   "include": ["src", "src/package.json", "test"],
   "compilerOptions": {
+    "rootDir": ".",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "resolveJsonModule": true,


### PR DESCRIPTION
Closes #22 
Closes #21 

Fixes some type errors:
1. Optional properties were still required to be provided
2. TypeScript compiler would stack overflow when calling `extend` 